### PR TITLE
Improve M1 performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ Optimized for macOS with limited RAM:
 - **Response Time**: Sub-second for most operations
 - **Local Storage**: SQLite for efficient data management
 
+### Mac M1 Specific Tips
+
+- AIDEN now uses `uvloop` when available for a faster event loop on Unix/Mac.
+- The Whisper STT automatically selects `int8` compute on Apple Silicon for
+  reduced latency.
+- When installing dependencies, use Homebrew Python or ensure arm64 wheels are
+  used for optimal performance.
+
 ## 🤝 Contributing
 
 1. Fork the repository

--- a/aiden_cli.py
+++ b/aiden_cli.py
@@ -16,6 +16,14 @@ Run: python aiden_cli.py
 import asyncio
 import json
 import os
+from backend.config import settings
+
+try:
+    if settings.USE_UVLOOP:
+        import uvloop
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+except Exception:
+    pass
 import sys
 import httpx
 import subprocess
@@ -117,10 +125,10 @@ class AidenCLI:
                 BarColumn(),
                 TaskProgressColumn(),
             ) as progress:
-                task = progress.add_task("Starting backend...", total=10)
-                
-                for i in range(10):
-                    await asyncio.sleep(1)
+                task = progress.add_task("Starting backend...", total=20)
+
+                for i in range(20):
+                    await asyncio.sleep(0.5)
                     progress.update(task, advance=1)
                     
                     status = await self.check_backend_status()
@@ -509,11 +517,11 @@ Whisper: {voice_config.get('whisper_model', 'Not configured')}""",
                 
                 # This would normally handle WebSocket connection for real-time voice
                 # For now, we'll show a placeholder interface
-                await asyncio.sleep(2)
+                await asyncio.sleep(1)
                 live.update("🔊 Voice mode ready - implement WebSocket client here")
                 
                 # Wait for user to interrupt
-                await asyncio.sleep(30)
+                await asyncio.sleep(10)
                 
         except KeyboardInterrupt:
             self.console.print("\n\n🔇 Voice mode stopped", style="yellow")

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -5,10 +5,19 @@ Initializes the FastAPI app, CORS, logging, and handles startup/shutdown events
 such as initializing the database and the agent.
 """
 import logging
+import asyncio
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from backend.config import settings
+
+try:
+    if settings.USE_UVLOOP:
+        import uvloop
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        logging.getLogger(__name__).info("Using uvloop event loop policy")
+except Exception:
+    pass
 from backend.core.memory import memory_manager # Updated import
 from backend.agent.agent_factory import initialize_global_agent, get_agent_instance # Updated import
 from .routes import router as api_router # Will create routes.py next

--- a/backend/config.py
+++ b/backend/config.py
@@ -41,6 +41,9 @@ class Settings:
     VOICE_ACTIVATION_THRESHOLD: float = float(os.getenv("VOICE_ACTIVATION_THRESHOLD", "0.02"))
     MAX_SILENCE_DURATION: float = float(os.getenv("MAX_SILENCE_DURATION", "2.0"))
 
+    # Performance
+    USE_UVLOOP: bool = os.getenv("USE_UVLOOP", "True").lower() in ("true", "1", "t")
+
     # Agent Configuration
     ENABLE_WEB_SEARCH: bool = os.getenv("ENABLE_WEB_SEARCH", "True").lower() in ("true", "1", "t")
     SHOW_TOOL_CALLS: bool = os.getenv("SHOW_TOOL_CALLS", "True").lower() in ("true", "1", "t")

--- a/backend/voice/stt.py
+++ b/backend/voice/stt.py
@@ -57,6 +57,16 @@ class WhisperSTT:
         self.silence_threshold = silence_threshold
         self.min_audio_length = min_audio_length
         self.language = language
+
+        # Auto-tune for Apple Silicon
+        if device == "auto" and compute_type == "auto":
+            import platform
+            if platform.system() == "Darwin" and platform.machine() == "arm64":
+                device = "cpu"
+                compute_type = "int8"
+
+        self.device = device
+        self.compute_type = compute_type
         
         # Initialize Whisper model
         logger.info(f"Loading Whisper model: {model_size}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,4 +44,5 @@ inquirer>=3.1.3  # Collection of common interactive command line user interfaces
 # pytest>=7.4.3  # Testing framework
 # pytest-asyncio>=0.21.1  # Async testing support
 # black>=23.11.0  # Code formatting
-# isort>=5.12.0  # Import sorting 
+# isort>=5.12.0  # Import sorting
+uvloop>=0.17.0  # High performance event loop for Unix/Mac


### PR DESCRIPTION
## Summary
- add uvloop to requirements and new USE_UVLOOP setting
- enable uvloop in CLI and FastAPI when available
- auto-tune Whisper STT for Apple Silicon
- speed up backend startup and voice mode waits
- document new M1 optimisation tips

## Testing
- `pip install -q -r requirements.txt` *(fails: building wheel for pyaudio)*
- `pytest -q` *(fails: ModuleNotFoundError for httpx, agno)*

------
https://chatgpt.com/codex/tasks/task_b_6840fa32f9e0832ea4f739608abfccf9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added optional high-performance event loop support for Unix/Mac systems to improve backend responsiveness.
	- Enhanced speech-to-text performance on Apple Silicon Macs with automatic device and compute optimizations.
- **Performance**
	- Finer-grained progress updates during backend startup for a smoother user experience.
	- Reduced wait times in voice mode for faster interactions.
- **Documentation**
	- Added a section with specific tips for optimizing performance on Mac M1 and Apple Silicon devices.
- **Chores**
	- Updated dependencies to include uvloop for improved event loop performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->